### PR TITLE
FreeBSD-USB-Quick-Formatter.py: fixes

### DIFF
--- a/FreeBSD-USB-Quick-Formatter.py
+++ b/FreeBSD-USB-Quick-Formatter.py
@@ -25,14 +25,14 @@ def addDrives():
 def run():
     if drivesCombo.get() != "": #checks if a drive is selected
         drive = "/dev/" + drivesCombo.get()
-        if formatCombo.get() == "FAT32":
+        if formatCombo.get() == "Ext4":
+            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s gpt " + drive + " && " + "sudo gpart add -t linux-data " + drive + " && sleep 5 && " + "sudo mke2fs -t ext4 " + drive + "p1"
+        elif formatCombo.get() == "FAT32":
             formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s mbr " + drive + " && " + "sudo gpart add -t fat32 " + drive + " && sleep 5 && " + "sudo newfs_msdos -F 32 " + drive + "s1"
-        elif formatCombo.get() == "UFS":
-            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s gpt " + drive + " && " + "sudo gpart add -t freebsd-ufs " + drive + " && sleep 5 && " + "sudo newfs " + drive + "p1"
         elif formatCombo.get() == "NTFS":
             formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s mbr " + drive + " && " + "sudo gpart add -t ntfs " + drive + " && sleep 5 && " + "sudo mkntfs --quick " + drive + "s1"
-        elif formatCombo.get() == "Ext4":
-            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s gpt " + drive + " && " + "sudo gpart add -t linux-data " + drive + " && sleep 5 && " + "sudo mke2fs -t ext4 " + drive + "p1"
+        elif formatCombo.get() == "UFS":
+            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s gpt " + drive + " && " + "sudo gpart add -t freebsd-ufs " + drive + " && sleep 5 && " + "sudo newfs " + drive + "p1"
         cmd = "xterm -hold -e '" + formatcmd + " && echo Done. You can close the window." + "'"
         confirmation = tkinter.messagebox.askquestion("Confirmation", "Command: " + formatcmd)
         if confirmation == "yes":
@@ -54,14 +54,14 @@ drivesLabel = tkinter.Label(root, text="Drives:", font=("", 10))
 drivesCombo = ttk.Combobox(root, values=drives, state="readonly", font=("", 10))
 drivesButton = ttk.Button(root, command=driveInfo, text="Show Drives Info")
 formatLabel = tkinter.Label(root, text="Format:", font=("", 10))
-formatCombo = ttk.Combobox(root, values=("FAT32", "UFS", "NTFS", "Ext4"), state="readonly", font=("", 10))
+formatCombo = ttk.Combobox(root, values=("Ext4", "FAT32", "NTFS", "UFS"), state="readonly", font=("", 10))
 formatCombo.current(0)
 refreshButton = ttk.Button(root, command=refresh, text="Refresh")
 runButton = ttk.Button(root, command=run, text="Run")
 
 
 tkinter.Label(root, font=("", 6)).pack() #empty line workaround
-tkinter.Label(root, text="Note: You need to umount the drives first", font=("", 8)).pack()
+tkinter.Label(root, text="If the drive's filesystem is mounted: unmount it before proceeding.", font=("", 9)).pack()
 tkinter.Label(root, font=("", 8)).pack()
 drivesLabel.pack()
 drivesCombo.pack()

--- a/FreeBSD-USB-Quick-Formatter.py
+++ b/FreeBSD-USB-Quick-Formatter.py
@@ -32,7 +32,7 @@ def run():
         elif formatCombo.get() == "NTFS":
             formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s mbr " + drive + " && " + "sudo gpart add -t ntfs " + drive + " && sleep 5 && " + "sudo mkntfs --quick " + drive + "s1"
         elif formatCombo.get() == "Ext4":
-            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s gpt " + drive + " && " + "sudo mke2fs -t ext4 " + drive
+            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s gpt " + drive + " && " + "sudo gpart add -t linux-data " + drive + "sudo mke2fs -t ext4 " + drive
         cmd = "xterm -hold -e '" + formatcmd + " && echo Done. You can close the window." + "'"
         confirmation = tkinter.messagebox.askquestion("Confirmation", "Command: " + formatcmd)
         if confirmation == "yes":

--- a/FreeBSD-USB-Quick-Formatter.py
+++ b/FreeBSD-USB-Quick-Formatter.py
@@ -32,7 +32,7 @@ def run():
         elif formatCombo.get() == "NTFS":
             formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s mbr " + drive + " && " + "sudo gpart add -t ntfs " + drive + " && sleep 5 && " + "sudo mkntfs --quick " + drive + "s1"
         elif formatCombo.get() == "Ext4":
-            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s gpt " + drive + " && " + "sudo gpart add -t linux-data " + drive + " && sleep 5 && " + "sudo mke2fs -t ext4 " + drive + "s1"
+            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s gpt " + drive + " && " + "sudo gpart add -t linux-data " + drive + " && sleep 5 && " + "sudo mke2fs -t ext4 " + drive + "p1"
         cmd = "xterm -hold -e '" + formatcmd + " && echo Done. You can close the window." + "'"
         confirmation = tkinter.messagebox.askquestion("Confirmation", "Command: " + formatcmd)
         if confirmation == "yes":

--- a/FreeBSD-USB-Quick-Formatter.py
+++ b/FreeBSD-USB-Quick-Formatter.py
@@ -26,14 +26,14 @@ def run():
     if drivesCombo.get() != "": #checks if a drive is selected
         drive = "/dev/" + drivesCombo.get()
         if formatCombo.get() == "FAT32":
-            formatcmd = "sudo gpart destroy -F " + drive + "; " + "sudo gpart create -s mbr " + drive + "; " + "sudo gpart add -t fat32 " + drive + "; " + "sudo newfs_msdos -F 32 " + drive + "s1"
+            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s mbr " + drive + " && " + "sudo gpart add -t fat32 " + drive + " && " + "sudo newfs_msdos -F 32 " + drive + "s1"
         elif formatCombo.get() == "UFS":
-            formatcmd = "sudo gpart destroy -F " + drive + "; " + "sudo gpart create -s gpt " + drive + "; " + "sudo gpart add -t freebsd-ufs " + drive + "; " + "sudo newfs " + drive + "p1"
+            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s gpt " + drive + " && " + "sudo gpart add -t freebsd-ufs " + drive + " && " + "sudo newfs " + drive + "p1"
         elif formatCombo.get() == "NTFS":
-            formatcmd = "sudo gpart destroy -F " + drive + "; " + "sudo gpart create -s mbr " + drive + "; " + "sudo gpart add -t ntfs " + drive + "; " + "sudo newfs " + drive + "s1"
+            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s mbr " + drive + " && " + "sudo gpart add -t ntfs " + drive + " && " + "sudo newfs " + drive + "s1"
         elif formatCombo.get() == "Ext4":
-            formatcmd = "sudo gpart destroy -F " + drive + "; " + "sudo gpart create -s gpt " + drive + "; " + "sudo mke2fs -t ext4 " + drive
-        cmd = "xterm -hold -e '" + formatcmd + "; echo Done. You can close the window." + "'"
+            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s gpt " + drive + " && " + "sudo mke2fs -t ext4 " + drive
+        cmd = "xterm -hold -e '" + formatcmd + " && echo Done. You can close the window." + "'"
         confirmation = tkinter.messagebox.askquestion("Confirmation", "Command: " + formatcmd)
         if confirmation == "yes":
             subprocess.call(cmd, shell=True)

--- a/FreeBSD-USB-Quick-Formatter.py
+++ b/FreeBSD-USB-Quick-Formatter.py
@@ -32,7 +32,7 @@ def run():
         elif formatCombo.get() == "NTFS":
             formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s mbr " + drive + " && " + "sudo gpart add -t ntfs " + drive + " && sleep 5 && " + "sudo mkntfs --quick " + drive + "s1"
         elif formatCombo.get() == "Ext4":
-            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s gpt " + drive + " && " + "sudo gpart add -t linux-data " + drive + "sudo mke2fs -t ext4 " + drive
+            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s gpt " + drive + " && " + "sudo gpart add -t linux-data " + drive + " && sleep 5 && " + "sudo mke2fs -t ext4 " + drive + "s1"
         cmd = "xterm -hold -e '" + formatcmd + " && echo Done. You can close the window." + "'"
         confirmation = tkinter.messagebox.askquestion("Confirmation", "Command: " + formatcmd)
         if confirmation == "yes":

--- a/FreeBSD-USB-Quick-Formatter.py
+++ b/FreeBSD-USB-Quick-Formatter.py
@@ -30,7 +30,7 @@ def run():
         elif formatCombo.get() == "UFS":
             formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s gpt " + drive + " && " + "sudo gpart add -t freebsd-ufs " + drive + " && " + "sudo newfs " + drive + "p1"
         elif formatCombo.get() == "NTFS":
-            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s mbr " + drive + " && " + "sudo gpart add -t ntfs " + drive + " && " + "sudo newfs " + drive + "s1"
+            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s mbr " + drive + " && " + "sudo gpart add -t ntfs " + drive + " && " + "sudo mkntfs --quick " + drive + "s1"
         elif formatCombo.get() == "Ext4":
             formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s gpt " + drive + " && " + "sudo mke2fs -t ext4 " + drive
         cmd = "xterm -hold -e '" + formatcmd + " && echo Done. You can close the window." + "'"

--- a/FreeBSD-USB-Quick-Formatter.py
+++ b/FreeBSD-USB-Quick-Formatter.py
@@ -44,7 +44,7 @@ def refresh():
     drivesCombo.configure(values=drives)
 
 def driveInfo():
-    subprocess.call("xterm -hold -e 'geom disk list'", shell=True)
+    subprocess.call("xterm -sb -hold -e 'geom disk list'", shell=True)
 
 
 addDrives()

--- a/FreeBSD-USB-Quick-Formatter.py
+++ b/FreeBSD-USB-Quick-Formatter.py
@@ -26,11 +26,11 @@ def run():
     if drivesCombo.get() != "": #checks if a drive is selected
         drive = "/dev/" + drivesCombo.get()
         if formatCombo.get() == "FAT32":
-            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s mbr " + drive + " && " + "sudo gpart add -t fat32 " + drive + " && " + "sudo newfs_msdos -F 32 " + drive + "s1"
+            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s mbr " + drive + " && " + "sudo gpart add -t fat32 " + drive + " && sleep 5 && " + "sudo newfs_msdos -F 32 " + drive + "s1"
         elif formatCombo.get() == "UFS":
-            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s gpt " + drive + " && " + "sudo gpart add -t freebsd-ufs " + drive + " && " + "sudo newfs " + drive + "p1"
+            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s gpt " + drive + " && " + "sudo gpart add -t freebsd-ufs " + drive + " && sleep 5 && " + "sudo newfs " + drive + "p1"
         elif formatCombo.get() == "NTFS":
-            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s mbr " + drive + " && " + "sudo gpart add -t ntfs " + drive + " && " + "sudo mkntfs --quick " + drive + "s1"
+            formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s mbr " + drive + " && " + "sudo gpart add -t ntfs " + drive + " && sleep 5 && " + "sudo mkntfs --quick " + drive + "s1"
         elif formatCombo.get() == "Ext4":
             formatcmd = "sudo gpart destroy -F " + drive + " ; " + "sudo gpart create -s gpt " + drive + " && " + "sudo mke2fs -t ext4 " + drive
         cmd = "xterm -hold -e '" + formatcmd + " && echo Done. You can close the window." + "'"

--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ This is a small tool for quickly formating USB drives (/dev/da* only) on FreeBSD
 
 ## Dependencies
 
-- Python 3
-- Tkinter
-- sudo
-- xterm
-- fusefs-ext2 *and* fusefs-ntfs
+- Python 3 – <https://www.freshports.org/lang/python3/>
+- Tkinter – one flavor e.g. `py311-tkinter` – <https://www.freshports.org/x11-toolkits/py-tkinter/>
+- sudo – <https://www.freshports.org/security/sudo/>
+- xterm – <https://www.freshports.org/x11/xterm/>
+- fusefs-ext2 – <https://www.freshports.org/filesystems/ext2/>
+- fusefs-ntfs – <https://www.freshports.org/filesystems/ntfs/>.
 
+Please note: [mkntfs(8)](https://man.freebsd.org/cgi/man.cgi?query=mkntfs&sektion=8&manpath=freebsd-ports) can **not** create an NTFS filesystem quickly with the FreeBSD Project-provided package of fusefs-ntfs. You can work around [FreeBSD bug 206978](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=206978) by building your own package with UBLIO disabled.
 
 ## Run
 
@@ -28,8 +30,14 @@ This is a small tool for quickly formating USB drives (/dev/da* only) on FreeBSD
 
 ## What it does
 
-It wipes everything on the USB drive and formats it. Only one partition is created, with the selected format. It uses GPT for UFS & Ext4 and MBR for FAT32 & NTFS.
+1. If any partition exists, delete all partitions
+2. add a single partition
+3. create a filesystem in the partition.
 
+Partition schemes: 
+
+- MBR for FAT32 and NTFS
+- GPT for Ext4 and UFS.
 
 ## More screenshots
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,26 @@
 # FreeBSD-USB-Quick-Formatter
 
-This is a small tool for quickly formating USB drives (/dev/da* only) on FreeBSD.
+**USB Quick Formatter** is a small tool for quickly formating USB drives – `/dev/da*` only – on FreeBSD.
 
-**Supported formats: FAT32, UFS, NTFS and Ext4**
+Supported filesystems: 
+
+- Ext4
+- FAT32
+- NTFS
+- UFS.
 
 ![Screenshot1](https://raw.githubusercontent.com/Liemaeu/FreeBSD-USB-Quick-Formatter/main/Screenshots/Screenshot1.png)
 
 ## Dependencies
 
 - Python 3 – <https://www.freshports.org/lang/python3/>
-- Tkinter – one flavor e.g. `py311-tkinter` – <https://www.freshports.org/x11-toolkits/py-tkinter/>
+- Tkinter – one flavor, for example `py311-tkinter` – <https://www.freshports.org/x11-toolkits/py-tkinter/>
 - sudo – <https://www.freshports.org/security/sudo/>
-- xterm – <https://www.freshports.org/x11/xterm/>
+- XTerm – <https://www.freshports.org/x11/xterm/>
 - fusefs-ext2 – <https://www.freshports.org/filesystems/ext2/>
 - fusefs-ntfs – <https://www.freshports.org/filesystems/ntfs/>.
 
-Please note: [mkntfs(8)](https://man.freebsd.org/cgi/man.cgi?query=mkntfs&sektion=8&manpath=freebsd-ports) can **not** create an NTFS filesystem quickly with the FreeBSD Project-provided package of fusefs-ntfs. You can work around [FreeBSD bug 206978](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=206978) by building your own package with UBLIO disabled.
+Please note: [mkntfs(8)](https://man.freebsd.org/cgi/man.cgi?query=mkntfs&sektion=8&manpath=freebsd-ports) can **not** create an NTFS filesystem _quickly_ with the FreeBSD Project-provided package of fusefs-ntfs. You can work around [bug 206978](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=206978) by building your own package with **UBLIO disabled**.
 
 ## Run
 
@@ -30,11 +35,11 @@ Please note: [mkntfs(8)](https://man.freebsd.org/cgi/man.cgi?query=mkntfs&sektio
 
 ## What it does
 
-1. If any partition exists, delete all partitions
-2. add a single partition
-3. create a filesystem in the partition.
+1. If any partition exists on the chosen device, destroy all partitions on the device
+2. add a single slice (MBR) or partition (GPT)
+3. create a filesystem.
 
-Partition schemes: 
+Preset partition schemes: 
 
 - MBR for FAT32 and NTFS
 - GPT for Ext4 and UFS.


### PR DESCRIPTION
Possible fixes for various issues.

Enhancement: add a partition before creating an Ext4 filesystem.

Update the README: avoid the FreeBSD Project-provided filesystems/ntfs
package (refer to UBLIO-related bug 206978), other suggested changes.