### PR TITLE
README: sudo python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Please note: [mkntfs(8)](https://man.freebsd.org/cgi/man.cgi?query=mkntfs&sektio
 
 ## Run
 
-`python3 FreeBSD-USB-Quick-Formatter.py`
+`sudo python3 FreeBSD-USB-Quick-Formatter.py`
 
 </br>
 </br>


### PR DESCRIPTION
sudo when running the .py file negates the need to subsequently enter the passphrase in a separate window.